### PR TITLE
Fix inaccurate loading hints

### DIFF
--- a/sw_tlk/sw_tlk.tlk.json
+++ b/sw_tlk/sw_tlk.tlk.json
@@ -59803,7 +59803,7 @@
     },
     {
       "id": 79766,
-      "text": "The maximum number of skill points you may have at one time is 350."
+      "text": "The maximum number of skill points you may have at one time is 400."
     },
     {
       "id": 79767,
@@ -59811,11 +59811,11 @@
     },
     {
       "id": 79768,
-      "text": "You can refund a perk and all spent SP by using a \"Tome of Retraining\". These can be purchased from NPCs."
+      "text": "You can refund a perk and all spent SP by using a \"Retraining Tome\". These can be purchased from training terminals."
     },
     {
       "id": 79769,
-      "text": "Your character has a maximum of 350 skill points total, distributed across all skills. Plan your character build carefully since you can't master everything. Every 10 skill points equals 1 Ability Point (AP) for a maximum of 35 AP."
+      "text": "Your character has a maximum of 400 skill points total, distributed across all skills. Plan your character build carefully since you can't master everything. Every 10 skill points equals 1 Ability Point (AP) for a maximum of 40 AP."
     },
     {
       "id": 79770,
@@ -59823,7 +59823,7 @@
     },
     {
       "id": 79771,
-      "text": "Investing in the Social ability score gives you significant XP bonuses when training skills - you gain +2.5% XP per point of Social modifier. This makes Social valuable for any character build."
+      "text": "Investing in the Social ability score gives you significant XP bonuses when training skills - you gain +2.5% XP per point of your Social ability score. This makes Social valuable for any character build."
     },
     {
       "id": 79772,
@@ -59831,7 +59831,7 @@
     },
     {
       "id": 79773,
-      "text": "Death results in losing XP and starting with only half health. You'll respawn at your registered medical center, so make sure to set a convenient respawn point."
+      "text": "Death causes you to accumulate XP debt and respawn with only half health. You'll respawn at your registered medical center, so make sure to set a convenient respawn point."
     },
     {
       "id": 79774,
@@ -59871,7 +59871,7 @@
     },
     {
       "id": 79783,
-      "text": "Consuming food provides XP bonuses that apply to crafting skills. Always eat appropriate food before major crafting sessions to maximize your skill gains."
+      "text": "Consuming food provides XP bonuses that apply to all skills. Always eat appropriate food before major training sessions to maximize your skill gains."
     },
     {
       "id": 79784,
@@ -59919,7 +59919,7 @@
     },
     {
       "id": 79795,
-      "text": "You can build your own city. Use your \"Property Tool\" feat to find out more."
+      "text": "You can build your own city by placing a City Hall structure. Founding a city requires the City Management perk."
     },
     {
       "id": 79796,
@@ -59951,7 +59951,7 @@
     },
     {
       "id": 79803,
-      "text": "Guild tasks refresh periodically and are randomly selected from available quests. If you don't like current tasks, wait for the rotation to get new options."
+      "text": "Guild tasks are randomly selected from the available quests each time the server restarts."
     },
     {
       "id": 79804,
@@ -64419,7 +64419,7 @@
     },
     {
       "id": 81102,
-      "text": "Repairing an item will restore its current durability and reduce its maximum durability. Use higher quality repair kits to reduce the amount of maximum durability lost."
+      "text": "When crafting, your Progress must reach the goal before Durability runs out. Spend CP wisely and keep Quality high to improve your results."
     },
     {
       "id": 81103,


### PR DESCRIPTION
Corrects 9 loading-hint TLK strings in `sw_tlk/sw_tlk.tlk.json` (and regenerates `sw_tlk.tlk`) that misstated game mechanics. Each fix was verified against the current server code on `feature/combat-upgrade`.

| Hint | Was | Now (why) |
|---|---|---|
| Skill cap | "...350" / "35 AP" | **400** / **40 AP** (`SkillCap=400`, `APCap=40`) |
| Retraining | "Tome of Retraining"...from NPCs | "**Retraining Tome**"...from **training terminals** (real item name; sold at a training-terminal placeable) |
| Social XP | "per point of Social **modifier**" | "...Social **ability score**" (code uses `GetAbilityScore`) |
| Death | "**losing XP**" | "**accumulate XP debt**" (death accrues debt; matches the other death hint) |
| Food | "apply to **crafting** skills" | "apply to **all** skills" (`ExperiencePercentAdjustment` feeds all `GiveSkillXP`) |
| City | "'Property Tool' feat" | "**City Hall** structure + **City Management** perk" (no such feat exists) |
| Guild | "**refresh periodically**" | "randomized **each server restart**" (`DateTasksLoaded` gate; set once) |
| Repair | item durability / repair kits | crafting **Progress/Durability** mechanic (no item-repair system exists) |

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated in-game tooltips and instructional text for skill points, Ability Points, perk retraining, XP debt, and social training.
  * Clarified that food bonuses apply to all skills.
  * Revised city-building and guild task guidance.
  * Updated crafting instructions to explain Progress and Durability requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->