### PR TITLE
Update Combat Analyzer Mimicry description

### DIFF
--- a/sw_tlk/sw_tlk.tlk.json
+++ b/sw_tlk/sw_tlk.tlk.json
@@ -88431,7 +88431,7 @@
     },
     {
       "id": 192575,
-      "text": "Grants a combat analyzer capable of recording enemy creature techniques. Unlocks technique learning and the Techniques window. Provides 2 technique slots and lets you replicate Mimicry 1-14 techniques."
+      "text": "Grants a combat analyzer capable of recording enemy creature techniques. Unlocks technique learning and the Techniques window. Provides 2 technique slots."
     },
     {
       "id": 192576,


### PR DESCRIPTION
## What changed

- Removed the obsolete `Mimicry 1-14` unlock range from the Combat Analyzer I description.
- Regenerated `sw_tlk.tlk` from the updated TLK JSON.

## Why

Mimicry techniques now have individual skill requirements derived from encounter progression, so the old analyzer tier-range wording is inaccurate.

## Player impact

Combat Analyzer I now accurately states that it unlocks technique learning, opens the Techniques window, and provides two technique slots.

## Validation

- Regenerated the binary TLK from `sw_tlk.tlk.json`.
- Verified the generated binary through a binary-to-JSON round trip.
- Parent Mimicry/Bible/NPC audit suite: 59 passed.