### PR TITLE
Simplify Guard damage descriptions

### DIFF
--- a/sw_tlk/sw_tlk.tlk.json
+++ b/sw_tlk/sw_tlk.tlk.json
@@ -15943,7 +15943,7 @@
     },
     {
       "id": 3985,
-      "text": "Whenever you Guard a hostile hit, release a pulse that deals 15 physical DMG to the attacker and all other enemies within 5 meters, using the standard combat damage formula. Each affected enemy generates Enmity toward you equal to the guarded hit's incoming damage."
+      "text": "Whenever you Guard a hostile hit, release a pulse that deals 15 physical DMG to the attacker and all other enemies within 5 meters. Each affected enemy generates Enmity toward you equal to the guarded hit's incoming damage."
     },
     {
       "id": 3986,
@@ -19795,7 +19795,7 @@
     },
     {
       "id": 4948,
-      "text": "For 30 seconds, you gain +20 Guard. Whenever you guard a hit, deal 8 physical DMG to that attacker using the standard combat damage formula. Your current Guarded target automatically receives the same effect if they are within 5 meters when activated."
+      "text": "For 30 seconds, you gain +20 Guard. Whenever you guard a hit, deal 8 physical DMG to that attacker. Your current Guarded target automatically receives the same effect if they are within 5 meters when activated."
     },
     {
       "id": 4949,


### PR DESCRIPTION
## What changed

- Removed the implementation-level phrase `using the standard combat damage formula` from the Iron Elbows and Whirling Guard player descriptions.
- Preserved the damage amount, damage type, radius, duration, Guard benefit, linked-target behavior, and Enmity behavior.
- Regenerated `sw_tlk.tlk` from the corrected JSON source.

## Why

Players only need the gameplay outcome. Calling out the engine's standard damage calculation adds unnecessary formula detail without helping them use either technique.

## Validation

- Parsed binary TLK entries `3985` and `4948` back to JSON and confirmed the shortened descriptions.
- Confirmed the removed phrase appears zero times in the regenerated binary.
- Companion main-repository update: zunath/SWLOR_NWN#2106.