### PR TITLE
Update Medical Injector Rig tooltip

### DIFF
--- a/sw_tlk/sw_tlk.tlk.json
+++ b/sw_tlk/sw_tlk.tlk.json
@@ -16387,7 +16387,7 @@
     },
     {
       "id": 4096,
-      "text": "Med Kit, Kolto Mist, Emergency Triage, and Infusion healing is increased by 10%."
+      "text": "All direct, area, and periodic healing caused by your abilities is increased by 5%."
     },
     {
       "id": 4097,


### PR DESCRIPTION
## Summary

- update the Medical Injector Rig TLK description for its new cross-skill healing scope
- document the 5% rank-one value with concise player-facing wording
- regenerate the binary TLK from the JSON source

## Why

The gameplay perk is being generalized from First Aid-only healing to eligible outgoing ability healing across skill trees. The player-facing tooltip now states the broad healing bonus without listing implementation-specific inclusions or exclusions.

## Validation

- regenerated `sw_tlk.tlk` from `sw_tlk.tlk.json`
- round-tripped the binary TLK and verified string ID 4096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated an ability description to accurately state that healing from player abilities is increased by 5%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->